### PR TITLE
Refactor condition to ensure userInput type check is top level

### DIFF
--- a/Controllers/MenuController.cs
+++ b/Controllers/MenuController.cs
@@ -1,5 +1,6 @@
 namespace ShellBank.Controllers
 {
+    using System.Formats.Asn1;
     using ShellBank.Models;
     using ShellBank.Services;
     using ShellBank.Views;
@@ -23,17 +24,22 @@ namespace ShellBank.Controllers
                 view.ShowBankList(bankService.GetBanks().Select(b => b.BankName).ToList());
                 view.ExitOption();
                 string? userInput = view.GetUserInput();
-                if (int.TryParse(userInput, out int bankIndex))
+
+                if (userInput == "0")
+                {
+                    running = false;
+                    view.ShowExitMessage();
+                    break;
+                }
+                else if (int.TryParse(userInput, out int bankIndex))
                 {
                     Bank? selectedBank = bankService.GetBankByIndex(bankIndex - 1);
+
+                   
                     if (selectedBank != null)
                     {
                         BankController bankController = new BankController(selectedBank);
                         bankController.ShowBankMenu();
-                    }
-                    else if (userInput == "0")
-                    {
-                        running = false;
                     }
                     else
                     {


### PR DESCRIPTION
The `ShowMainMenu` logic in `MenuController.cs` to improve how exiting is handled and to clarify the user flow. The main change is that the exit option is now checked before trying to parse numeric input, and the exit message is shown when the user chooses to exit.

**User input handling improvements:**

* In `ShowMainMenu`, the code now checks if `userInput` is `"0"` before attempting to parse it as a number, ensuring that the exit option is handled first and more clearly. The exit message is also displayed when the user chooses to exit.

