### PR TITLE
Add bank selection menu to Menu Controller

### DIFF
--- a/Controllers/MenuController.cs
+++ b/Controllers/MenuController.cs
@@ -1,6 +1,5 @@
 namespace ShellBank.Controllers
 {
-    using System.Formats.Asn1;
     using ShellBank.Models;
     using ShellBank.Services;
     using ShellBank.Views;
@@ -20,9 +19,10 @@ namespace ShellBank.Controllers
             bool running = true;
             while (running)
             {
-                var role = new RoleSelctionMenu();
+                RoleSelctionMenu role = new RoleSelctionMenu();
                 role.PromptRoleSelction();
-                Console.ReadLine();
+                BankSelectionMenu bankMenu = new BankSelectionMenu();
+                Bank? selectedBank = bankMenu.PromptBankSelection(bankService.GetAllBanks());
             }
         }
     }

--- a/Views/BankSelctionMenu.cs
+++ b/Views/BankSelctionMenu.cs
@@ -1,0 +1,39 @@
+namespace ShellBank.Views
+{
+    using Spectre.Console;
+    using ShellBank.Models;
+ 
+    class BankSelectionMenu : BaseView
+    {
+        public Bank? PromptBankSelection(List<Bank> banks)
+        {
+            Console.Clear();
+ 
+            AnsiConsole.Write(new Rule("[steelblue1]Select Your Bank[/]").RuleStyle("grey").Centered());
+            AnsiConsole.WriteLine();
+ 
+            if (banks.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[red]No banks are currently registered.[/]");
+                AnsiConsole.MarkupLine("[grey]Press any key to go back...[/]");
+                Console.ReadKey(intercept: true);
+                return null;
+            }
+ 
+            var choices = banks.Select(b => b.Name).ToList();
+            choices.Add("[grey]← Go back[/]");
+ 
+            var selected = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("[bold]Choose a bank:[/]")
+                    .PageSize(10)
+                    .AddChoices(choices)
+            );
+ 
+            if (selected == "[grey]← Go back[/]")
+                return null;
+ 
+            return banks.FirstOrDefault(b => b.Name == selected);
+        }
+    }
+}


### PR DESCRIPTION
**New Feature: Bank Selection Menu**

* Added a new `BankSelectionMenu` class in `Views/BankSelctionMenu.cs`, which provides a user interface for selecting a bank from a list using `Spectre.Console`. It handles the case where no banks are registered and allows the user to go back.

**Main Menu Flow Updates**

* Updated the `ShowMainMenu` method in `Controllers/MenuController.cs` to instantiate and display the new `BankSelectionMenu` after role selection, and to retrieve the selected bank.

**Code Cleanup**

* Removed an unused `System.Formats.Asn1` using directive from `Controllers/MenuController.cs`.