### PR TITLE
Add validation for 4-digit numeric registration number

### DIFF
--- a/Controllers/DevModeController.cs
+++ b/Controllers/DevModeController.cs
@@ -1,5 +1,7 @@
 namespace ShellBank.Controllers
 {
+    using System.Runtime.CompilerServices;
+    using System.Text.RegularExpressions;
     using ShellBank.Models;
     using ShellBank.Services;
     using ShellBank.Views;
@@ -16,6 +18,7 @@ namespace ShellBank.Controllers
 
         public void ShowDevModeMenu()
         {
+
             DevModeView view = new DevModeView();
             DevModeView.DevModeOption option = view.PromptDevModeOption();
 
@@ -23,8 +26,13 @@ namespace ShellBank.Controllers
             {
                 case DevModeView.DevModeOption.CreateBank:
                     string bankName = AnsiConsole.Ask<string>("Enter bank name:");
-                    Console.Write("Enter Registraion Number (or press Enter to auto-generate): ");
-                    string? registrationNumber = Console.ReadLine();
+                    string registrationNumber = AnsiConsole.Ask<string>("Enter registration number (leave blank for auto-generation)", "");
+                    if (!string.IsNullOrEmpty(registrationNumber) && (Convert.ToInt32(registrationNumber) < 1000 || Convert.ToInt32(registrationNumber) > 9999))
+                    {
+                        AnsiConsole.MarkupLine("[red]Registration number must be a 4-digit number. Auto-generating registration number.[/]");
+                        registrationNumber = "";
+                    }
+                    
                     Bank newBank = bankService.CreateBank(bankName, registrationNumber);
                     AnsiConsole.MarkupLine($"[green]Bank '{newBank.Name}' created successfully![/]");
                     AnsiConsole.MarkupLine($"[green]Registration Number: {newBank.RegistrationNumber}[/]");

--- a/Controllers/DevModeController.cs
+++ b/Controllers/DevModeController.cs
@@ -27,6 +27,11 @@ namespace ShellBank.Controllers
                 case DevModeView.DevModeOption.CreateBank:
                     string bankName = AnsiConsole.Ask<string>("Enter bank name:");
                     string registrationNumber = AnsiConsole.Ask<string>("Enter registration number (leave blank for auto-generation)", "");
+                    if (Regex.IsMatch(registrationNumber, "[A-Za-z]"))
+                    {
+                        AnsiConsole.MarkupLine("[red]Registration number must be numeric. Auto-generating registration number.[/]");
+                        break;
+                    }
                     if (!string.IsNullOrEmpty(registrationNumber) && (Convert.ToInt32(registrationNumber) < 1000 || Convert.ToInt32(registrationNumber) > 9999))
                     {
                         AnsiConsole.MarkupLine("[red]Registration number must be a 4-digit number. Auto-generating registration number.[/]");

--- a/Controllers/DevModeController.cs
+++ b/Controllers/DevModeController.cs
@@ -1,6 +1,5 @@
 namespace ShellBank.Controllers
 {
-    using System.Runtime.CompilerServices;
     using System.Text.RegularExpressions;
     using ShellBank.Models;
     using ShellBank.Services;


### PR DESCRIPTION
This pull request improves input validation and user feedback in the developer mode bank creation flow. The main focus is on ensuring that the registration number entered by the user is numeric and within the required range, with appropriate messages displayed for invalid input.

Input validation and user feedback improvements:

* Added checks to ensure the registration number entered is numeric; if not, an error message is shown and registration number is auto-generated.
* Added validation to ensure the registration number is a 4-digit number between 1000 and 9999; otherwise, an error message is displayed and the registration number is auto-generated.
* Enhanced user prompts to clarify that leaving the registration number blank will trigger auto-generation.
